### PR TITLE
fix: Move better-sqlite3 to runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,14 @@
     "release": "bumpp && pnpm publish",
     "prepublishOnly": "pnpm run build"
   },
+  "dependencies": {
+    "better-sqlite3": "^12.2.0"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.0.0",
     "@libsql/client": "^0.15.9",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.15.17",
-    "better-sqlite3": "^12.2.0",
     "bumpp": "^10.1.0",
     "drizzle-kit": "^0.31.4",
     "drizzle-orm": "^0.44.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      better-sqlite3:
+        specifier: ^12.2.0
+        version: 12.2.0
     devDependencies:
       '@biomejs/biome':
         specifier: 2.0.0
@@ -20,9 +24,6 @@ importers:
       '@types/node':
         specifier: ^22.15.17
         version: 22.16.0
-      better-sqlite3:
-        specifier: ^12.2.0
-        version: 12.2.0
       bumpp:
         specifier: ^10.1.0
         version: 10.2.0


### PR DESCRIPTION
## Summary
- Moved `better-sqlite3` from devDependencies to dependencies since it's required at runtime

## Test plan
- [x] Package installs correctly with production dependencies only
- [x] Database functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)