### PR TITLE
ci: Fix CI configuration issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v4.1.0
         with:
           version: latest
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.1.0
+        with:
+          version: latest
 
       - name: Set node LTS
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "url": "git+https://github.com/tuanemuy/local-task.git"
   },
   "author": "maku.",
-  "packageManager": "pnpm@10.12.4",
   "files": [
     "dist",
     "drizzle"


### PR DESCRIPTION
## Summary
- Fix pnpm action setup with proper version configuration in both release and unit-test workflows
- Remove packageManager field from package.json to prevent version conflicts with CI environments
- Ensure consistent workflow setup across all GitHub Actions jobs

## Test plan
- [ ] Verify GitHub Actions workflows run successfully
- [ ] Check that pnpm installation works correctly in CI
- [ ] Confirm no version conflicts occur during CI execution

🤖 Generated with [Claude Code](https://claude.ai/code)