### PR TITLE
feat: add customId support to done and wip commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A lightweight CLI task manager for npm projects using SQLite for local storage.
 - **Category-based Organization**: Organize tasks into custom categories
 - **SQLite Storage**: Local database storage with no external dependencies
 - **Flexible Task Management**: Add, update, search, and track task status
+- **Dual ID Support**: Use either numeric IDs or custom string IDs for task operations
 - **JSON Integration**: Import/export tasks in JSON format
 - **Status Tracking**: Mark tasks as work-in-progress (wip) or done
 - **Search Capabilities**: Full-text search across task names and descriptions
@@ -108,21 +109,22 @@ List tasks with "wip" (work-in-progress) status.
 npx local-task todo backend
 ```
 
-#### `done <category> <id> [comment]`
+#### `done <category> <id|customId> [comment]`
 
 Mark a task as completed with optional comment.
 
 ```bash
 npx local-task done backend 1 "API implementation completed"
-npx local-task done backend "api-001"
+npx local-task done backend api-001 "API implementation completed"
 ```
 
-#### `wip <category> <id> [comment]`
+#### `wip <category> <id|customId> [comment]`
 
 Mark a task as work-in-progress with optional comment.
 
 ```bash
 npx local-task wip backend 1 "Starting API development"
+npx local-task wip backend api-001 "Starting API development"
 ```
 
 ### Search and Remove

--- a/src/commands/wip.ts
+++ b/src/commands/wip.ts
@@ -1,18 +1,21 @@
-import { eq, and } from "drizzle-orm";
+import { eq, and, or } from "drizzle-orm";
 import { schema } from "../db";
 import type { DatabaseConnection } from "../utils/db";
-import { validateTaskId, handleCommandError } from "../utils/validation";
+import { handleCommandError } from "../utils/validation";
 
 export async function wip(
   dbConnection: DatabaseConnection,
   category: string,
-  id: string,
+  idOrCustomId: string,
   comment?: string,
 ) {
   const { db } = dbConnection;
 
   try {
-    const taskId = validateTaskId(id);
+    // Try to parse as number for id (only positive integers are considered valid IDs)
+    const id = Number.parseInt(idOrCustomId, 10);
+    const isValidNumericId =
+      !Number.isNaN(id) && id > 0 && /^\d+$/.test(idOrCustomId);
 
     const result = await db
       .update(schema.tasks)
@@ -21,15 +24,23 @@ export async function wip(
         comment: comment || null,
       })
       .where(
-        and(eq(schema.tasks.category, category), eq(schema.tasks.id, taskId)),
+        and(
+          eq(schema.tasks.category, category),
+          or(
+            isValidNumericId ? eq(schema.tasks.id, id) : undefined,
+            eq(schema.tasks.customId, idOrCustomId),
+          ),
+        ),
       );
 
     if (result.changes === 0) {
-      console.error(`Task with id ${id} not found in category '${category}'`);
-      throw new Error(`Task with id ${id} not found`);
+      console.error(
+        `Task not found with ${isValidNumericId ? "id" : "customId"}: ${idOrCustomId} in category '${category}'`,
+      );
+      throw new Error(`Task not found: ${idOrCustomId}`);
     }
 
-    console.log(`Task ${id} marked as work in progress`);
+    console.log(`Task ${idOrCustomId} marked as work in progress`);
   } catch (error) {
     handleCommandError("mark task as wip", error);
   }


### PR DESCRIPTION
## Summary
Adds support for using customId in addition to numeric ID for the `done` and `wip` commands, bringing them to parity with the `get` command.

## Changes
- **Enhanced done command**: Now accepts both `id` and `customId` parameters
- **Enhanced wip command**: Now accepts both `id` and `customId` parameters  
- **Flexible ID resolution**: Uses same smart logic as `get` command to detect numeric vs custom IDs
- **Updated tests**: All existing tests updated + new tests for customId functionality
- **Documentation**: README updated to reflect new dual ID support

## Test plan
- [x] All existing tests continue to pass (229 total)
- [x] New customId functionality tests added and passing
- [x] TypeScript compilation successful
- [x] Linting and formatting checks pass
- [x] Manual testing of both numeric ID and customId usage

🤖 Generated with [Claude Code](https://claude.ai/code)